### PR TITLE
Unwrap Optional when serialising description

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.rspace-os</groupId>
     <artifactId>rda-dmp-common-standard</artifactId>
-    <version>0.0.1</version>
+    <version>0.0.2</version>
 
     <name>rda-dmp-common-standard</name>
     <build>

--- a/src/main/java/com/researchspace/rda/model/DMP.java
+++ b/src/main/java/com/researchspace/rda/model/DMP.java
@@ -61,6 +61,11 @@ public class DMP {
     this.description = Optional.ofNullable(description);
   }
 
+  @JsonProperty("description")
+  public String getDescription() {
+    return this.description.orElse(null);
+  }
+
   private DmpId dmpId;
 
   /*


### PR DESCRIPTION
Description is optional, and so when it is serialised to JSON the optional object wrapping the string was being serialised. Instead, the value should simply be null when not available.