### PR TITLE
RSPAC-2784 Add setters for optional private properties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.rspace-os</groupId>
     <artifactId>rda-dmp-common-standard</artifactId>
-    <version>0.0.2</version>
+    <version>0.0.3</version>
 
     <name>rda-dmp-common-standard</name>
     <build>

--- a/src/main/java/com/researchspace/rda/model/Distribution.java
+++ b/src/main/java/com/researchspace/rda/model/Distribution.java
@@ -121,7 +121,7 @@ public class Distribution {
   private Optional<Host> host;
 
   @JsonProperty("host")
-  public void setHost(Long host) {
+  public void setHost(Host host) {
     this.host = Optional.ofNullable(host);
   }
 

--- a/src/main/java/com/researchspace/rda/model/Distribution.java
+++ b/src/main/java/com/researchspace/rda/model/Distribution.java
@@ -57,6 +57,11 @@ public class Distribution {
 
   private Optional<Long> byteSize;
 
+  @JsonProperty("byteSize")
+  public void setByteSize(Long byteSize) {
+    this.byteSize = Optional.ofNullable(byteSize);
+  }
+
   public enum DataAccess {
 
     @JsonProperty("open")
@@ -114,6 +119,11 @@ public class Distribution {
    * (e.g. repository) where data is stored.
    */
   private Optional<Host> host;
+
+  @JsonProperty("host")
+  public void setHost(Long host) {
+    this.host = Optional.ofNullable(host);
+  }
 
   private Set<License> license;
 

--- a/src/main/java/com/researchspace/rda/model/Host.java
+++ b/src/main/java/com/researchspace/rda/model/Host.java
@@ -75,6 +75,11 @@ public class Host {
 
   private Optional<CertificationStandard> certifiedWith;
 
+  @JsonProperty("certifiedWith")
+  public void setCertifiedWith(Long certifiedWith) {
+    this.certifiedWith = Optional.ofNullable(certifiedWith);
+  }
+
   private Optional<String> description;
 
   @JsonProperty("description")
@@ -163,6 +168,11 @@ public class Host {
   }
 
   private Optional<YesNo> supportsVersioning;
+
+  @JsonProperty("supportsVersioning")
+  public void setSupportsVersioning(Long supportsVersioning) {
+    this.supportsVersioning = Optional.ofNullable(supportsVersioning);
+  }
 
   private String title;
 

--- a/src/main/java/com/researchspace/rda/model/Host.java
+++ b/src/main/java/com/researchspace/rda/model/Host.java
@@ -76,7 +76,7 @@ public class Host {
   private Optional<CertificationStandard> certifiedWith;
 
   @JsonProperty("certifiedWith")
-  public void setCertifiedWith(Long certifiedWith) {
+  public void setCertifiedWith(CertificationStandard certifiedWith) {
     this.certifiedWith = Optional.ofNullable(certifiedWith);
   }
 
@@ -170,7 +170,7 @@ public class Host {
   private Optional<YesNo> supportsVersioning;
 
   @JsonProperty("supportsVersioning")
-  public void setSupportsVersioning(Long supportsVersioning) {
+  public void setSupportsVersioning(YesNo supportsVersioning) {
     this.supportsVersioning = Optional.ofNullable(supportsVersioning);
   }
 

--- a/src/main/java/com/researchspace/rda/model/Metadata.java
+++ b/src/main/java/com/researchspace/rda/model/Metadata.java
@@ -6,6 +6,8 @@ import lombok.NoArgsConstructor;
 import java.util.Optional;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 @Data
 @AllArgsConstructor

--- a/src/main/java/com/researchspace/rda/model/Metadata.java
+++ b/src/main/java/com/researchspace/rda/model/Metadata.java
@@ -15,6 +15,11 @@ public class Metadata {
 
   private Optional<String> description;
 
+  @JsonProperty("description")
+  public void setDescription(String description) {
+    this.description = Optional.ofNullable(description);
+  }
+
   /*
    * Language of the metadata expressed using ISO 639-3.
    */


### PR DESCRIPTION
These private fields we missing deserialisers for the Optional wrapper class. As such, if a DMP had a non-null value for any of these properties it would fail to import into RSpace.