### PR TITLE
[RSDEV-241] [RSDEV-162]: Make the DMPTool deserialization more robust

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     
     <artifactId>rda-dmp-common-standard</artifactId>
-    <version>0.0.4</version>
+    <version>0.0.5</version>
     <name>rda-dmp-common-standard</name>
 
     <parent>

--- a/src/main/java/com/researchspace/rda/model/Contact.java
+++ b/src/main/java/com/researchspace/rda/model/Contact.java
@@ -1,11 +1,11 @@
 package com.researchspace.rda.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.AllArgsConstructor;
-import lombok.NoArgsConstructor;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 
 /**
  * For modelling a party which can provide any information on the DMP. This is
@@ -15,6 +15,7 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 @AllArgsConstructor
 @NoArgsConstructor
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown=true)
 public class Contact {
 
   // Identifier for a contact person

--- a/src/main/java/com/researchspace/rda/model/Contributor.java
+++ b/src/main/java/com/researchspace/rda/model/Contributor.java
@@ -1,14 +1,14 @@
 package com.researchspace.rda.model;
 
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.AllArgsConstructor;
-import lombok.NoArgsConstructor;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import java.util.Optional;
 import java.util.Set;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 /**
  * For modelling a party involved in the process of the data management
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 @AllArgsConstructor
 @NoArgsConstructor
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown=true)
 public class Contributor {
 
   private PersonId contactId;

--- a/src/main/java/com/researchspace/rda/model/Cost.java
+++ b/src/main/java/com/researchspace/rda/model/Cost.java
@@ -1,12 +1,13 @@
 package com.researchspace.rda.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.util.Optional;
+import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.AllArgsConstructor;
-import java.util.Optional;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 
 /**
  * For modelling a cost related to data management.
@@ -15,6 +16,7 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 @NoArgsConstructor
 @AllArgsConstructor
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown=true)
 public class Cost {
 
   // MUST be a currency code from ISO-4217

--- a/src/main/java/com/researchspace/rda/model/DMP.java
+++ b/src/main/java/com/researchspace/rda/model/DMP.java
@@ -1,23 +1,23 @@
 package com.researchspace.rda.model;
 
-import lombok.Data;
-import lombok.AllArgsConstructor;
-import lombok.NoArgsConstructor;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.List;
-import java.util.Map;
-import java.net.URI;
-import com.fasterxml.jackson.annotation.JsonSetter;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
-import java.net.URISyntaxException;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown=true)
 public class DMP {
 
   /*

--- a/src/main/java/com/researchspace/rda/model/Dataset.java
+++ b/src/main/java/com/researchspace/rda/model/Dataset.java
@@ -1,14 +1,14 @@
 package com.researchspace.rda.model;
 
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.AllArgsConstructor;
-import lombok.NoArgsConstructor;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import java.util.Optional;
 import java.util.Set;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 /**
  * This follows the definition of Dataset in the W3C DCAT specification.
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 @AllArgsConstructor
 @NoArgsConstructor
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown=true)
 public class Dataset {
 
   public static class DatasetId {

--- a/src/main/java/com/researchspace/rda/model/DmpId.java
+++ b/src/main/java/com/researchspace/rda/model/DmpId.java
@@ -1,16 +1,15 @@
 package com.researchspace.rda.model;
 
-import lombok.Data;
-import lombok.AllArgsConstructor;
-import lombok.NoArgsConstructor;
-import java.util.Optional;
-import java.util.Set;
-import java.net.URI;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown=true)
 public class DmpId {
 
   private String identifier;

--- a/src/main/java/com/researchspace/rda/model/Funding.java
+++ b/src/main/java/com/researchspace/rda/model/Funding.java
@@ -1,14 +1,13 @@
 package com.researchspace.rda.model;
 
-import lombok.Data;
-import lombok.AllArgsConstructor;
-import lombok.NoArgsConstructor;
-import java.util.Optional;
-import java.util.Set;
-import java.net.URI;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.util.Optional;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 /*
  * For specifying details on funded projects, e.g. NSF of EC funded projects.
@@ -17,6 +16,7 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 @AllArgsConstructor
 @NoArgsConstructor
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown=true)
 public class Funding {
 
   private FundingId funderId;

--- a/src/main/java/com/researchspace/rda/model/FundingId.java
+++ b/src/main/java/com/researchspace/rda/model/FundingId.java
@@ -1,12 +1,14 @@
 package com.researchspace.rda.model;
 
-import lombok.Data;
-import lombok.AllArgsConstructor;
-import lombok.NoArgsConstructor;
-import java.util.Optional;
-import java.util.Set;
-import java.net.URI;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
 @AllArgsConstructor
@@ -24,7 +26,33 @@ public class FundingId {
     URL,
 
     @JsonProperty("other")
-    OTHER
+    OTHER;
+
+    private static Map<String, FunderIdType> namesMap = new HashMap<>(3);
+
+    static {
+      namesMap.put("fundref", FUNDREF);
+      namesMap.put("url", URL);
+      namesMap.put("other", OTHER);
+    }
+
+    @JsonCreator
+    public static FunderIdType forValue(String value) {
+      if (value != null) {
+        return namesMap.get(value.toLowerCase());
+      }
+      return null;
+    }
+
+    @JsonValue
+    public String toValue() {
+      for (Entry<String, FunderIdType> entry : namesMap.entrySet()) {
+        if (entry.getValue() == this) {
+          return entry.getKey();
+        }
+      }
+      return null; // ignore the value
+    }
 
   }
 

--- a/src/main/java/com/researchspace/rda/model/PersonId.java
+++ b/src/main/java/com/researchspace/rda/model/PersonId.java
@@ -1,10 +1,10 @@
 package com.researchspace.rda.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.AllArgsConstructor;
-import lombok.NoArgsConstructor;
-import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * Whilst not specifically declared by the spec, this class models the concept
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown=true)
 public class PersonId {
 
   public enum PersonIdType {

--- a/src/main/java/com/researchspace/rda/model/Project.java
+++ b/src/main/java/com/researchspace/rda/model/Project.java
@@ -1,12 +1,12 @@
 package com.researchspace.rda.model;
 
-import lombok.Data;
-import lombok.AllArgsConstructor;
-import lombok.NoArgsConstructor;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Optional;
 import java.util.Set;
-import java.net.URI;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 /*
  * Describes the project associated with the DMP, if applicable. It can be used
@@ -16,6 +16,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown=true)
 public class Project {
 
   private Optional<String> description;


### PR DESCRIPTION
In order of not adding new values that we don't use on the FunderIdType, i've redefined the way we serialize/deserialize so that we can ignore the enum values that are not defined without blowing up an exception